### PR TITLE
Specify braindecode package version 0.3.2

### DIFF
--- a/brainDecode/2 - Two-Classes Classification (BNCI) Colab.ipynb
+++ b/brainDecode/2 - Two-Classes Classification (BNCI) Colab.ipynb
@@ -590,7 +590,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install braindecode -q"
+    "!pip install braindecode==0.3.2 -q"
    ]
   },
   {


### PR DESCRIPTION
New braindecode version 0.4.0 as of 11 hours ago. Running previous notebook version installs braindecode 0.4.0 resulting in the following error:

```
/usr/local/lib/python3.6/dist-packages/braindecode/models/shallow_fbcsp.py in create_network(self)
    88
    89         # Initialization, xavier is same as in paper...
---> 90         init.xavier_uniform_(model.conv_time.weight, gain=1)
    91         # maybe no bias in case of no split layer and batch norm
    92         if self.split_first_layer or (not self.batch_norm):
AttributeError: module 'torch.nn.init' has no attribute 'xavier_uniform_'
```